### PR TITLE
Resolved meta-package for compatibility with Debian-distro

### DIFF
--- a/rootfs/DEBIAN/control
+++ b/rootfs/DEBIAN/control
@@ -5,7 +5,7 @@ Priority: optional
 Architecture: amd64
 Suggests: virt-manager, numactl, hwloc
 Depends: debootstrap (>=1.0.59~), gdisk, qemu-utils, e2fsprogs, lvm2,
- libvirt-bin, qemu-kvm, qemu-system, virtinst, bridge-utils, ifenslave,
+ libvirt-clients, libvirt-daemon-system, qemu-kvm, qemu-system, virtinst, bridge-utils, ifenslave,
  ssh-askpass, kpartx, psmisc
 Maintainer: MORKNet <webadmin@morknet.de>
 Homepage: https://intra.morknet.de/


### PR DESCRIPTION
[libvirt-bin](https://packages.ubuntu.com/bionic/libvirt-bin) ist offenbar ein Metapaket, das es so für stretch, buster, etc. nicht gibt. Ich habe die Meta-Paket-Abhängigkeit durch die darin verzeichneten Depends ersetzt. Auf meinem Ubuntu 20.04 Heimrechner installiert das Paket dann. Den kvm-hostcreator selber habe ich noch nicht probiert, und auch die Paket-Installation auf dem Debian buster ist noch ungetestet. 