### PR TITLE
Added dependencies for growing partitions.

### DIFF
--- a/rootfs/DEBIAN/control
+++ b/rootfs/DEBIAN/control
@@ -6,7 +6,7 @@ Architecture: amd64
 Suggests: virt-manager, numactl, hwloc
 Depends: debootstrap (>=1.0.59~), gdisk, qemu-utils, e2fsprogs, lvm2,
  libvirt-clients, libvirt-daemon-system, qemu-kvm, qemu-system, virtinst, bridge-utils, ifenslave,
- ssh-askpass, kpartx, psmisc, gnupg2
+ ssh-askpass, kpartx, psmisc, gnupg2, fdisk, gdisk, cloud-guest-utils
 Maintainer: Steffen A. Mork <linux-dev@morknet.de>
 Homepage: https://morknet.de/
 Description: This package provides scripts for creating KVM hosts.


### PR DESCRIPTION
It is suitable to use partition tools on a host and inside the VM. It may also be possible to use ELBE to create SD card images which makes it necessary to expand predefined partition tables on real SD cards.